### PR TITLE
Fixed Dockerifle build for provisioning "eb" cli command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.9
 
 ARG command="--version"
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This action run [eb cli](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/
 ## Example usage
 
 ```YAML
-uses: hmanzur/actions-aws-eb@v1.0.0
+uses: 7codeRO/actions-aws-eb@master
 with:
   command: 'deploy ${{ secrets.ENVIRONMENT_NAME }}'
 env:


### PR DESCRIPTION
The error output from Github action. 


```
Build container for action use: '/home/runner/work/_actions/hmanzur/actions-aws-eb/v1.0.0/Dockerfile'.
  /usr/bin/docker build -t 5bedb4:043[2](https://github.com/Rubrick-AI/websocket/actions/runs/5730946873/job/15530786415#step:2:2)35e6b24b4a21b314a2ddeb1c2916 -f "/home/runner/work/_actions/hmanzur/actions-aws-eb/v1.0.0/Dockerfile" "/home/runner/work/_actions/hmanzur/actions-aws-eb/v1.0.0"
  Sending build context to Docker daemon   12.8kB
  
  Step 1/7 : FROM python:3
  3: Pulling from library/python
  785ef8b9b236: Pulling fs layer
  5a6dad8f55ae: Pulling fs layer
  bd36c7bfe5f4: Pulling fs layer
  4d207285f6d2: Pulling fs layer
  9402da1694b8: Pulling fs layer
  9bdbf45d01af: Pulling fs layer
  dd8b7ef87a9d: Pulling fs layer
  4de52e7027c5: Pulling fs layer
  4d207285f6d2: Waiting
  9402da1694b8: Waiting
  9bdbf45d01af: Waiting
  dd8b7ef87a9d: Waiting
  4de52e7027c5: Waiting
  5a6dad8f55ae: Verifying Checksum
  5a6dad8f55ae: Download complete
  785ef8b9b236: Verifying Checksum
  785ef8b9b236: Download complete
  bd36c7bfe5f4: Verifying Checksum
  bd36c7bfe5f4: Download complete
  9402da1694b8: Verifying Checksum
  9402da1694b8: Download complete
  9bdbf45d01af: Verifying Checksum
  9bdbf45d01af: Download complete
  dd8b7ef87a9d: Verifying Checksum
  dd8b7ef87a9d: Download complete
  4de52e7027c5: Verifying Checksum
  4de52e7027c5: Download complete
  4d207285f6d2: Verifying Checksum
  4d207285f6d2: Download complete
  785ef8b9b236: Pull complete
  5a6dad8f55ae: Pull complete
  bd36c7bfe5f4: Pull complete
  4d207285f6d2: Pull complete
  9402da1694b8: Pull complete
  9bdbf45d01af: Pull complete
  dd8b7ef87a9d: Pull complete
  4de52e7027c5: Pull complete
  Digest: sha256:9a1b705aecedc76e8bf87dfca091d7093df3f2dd4765af6c250134ce4298a584
  Status: Downloaded newer image for python:3
   ---> 608c79ebc6d5
  Step 2/7 : ARG command="--version"
   ---> Running in fb380b9d2c10
  Removing intermediate container fb380b9d2c10
   ---> 64649b4d89e9
  Step 3/7 : COPY entrypoint.sh /entrypoint.sh
   ---> dd2589c73ba6
  Step 4/7 : RUN apt-get update -y
   ---> Running in e4d1bd8c05af
  Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB]
  Get:2 http://deb.debian.org/debian bookworm-updates InRelease [52.1 kB]
  Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
  Get:4 http://deb.debian.org/debian bookworm/main amd64 Packages [8906 kB]
  Get:5 http://deb.debian.org/debian bookworm-updates/main amd64 Packages [4732 B]
  Get:6 http://deb.debian.org/debian-security bookworm-security/main amd64 Packages [49.1 kB]
  Fetched 9211 kB in 1s (6224 kB/s)
  Reading package lists...
  Removing intermediate container e4d1bd8c05af
   ---> 6e021d2baf45
  Step 5/7 : RUN pip install --upgrade pip awsebcli
   ---> Running in 1a422a07fd3a
  Requirement already satisfied: pip in /usr/local/lib/python3.11/site-packages (23.1.2)
  Collecting pip
    Downloading pip-23.2.1-py3-none-any.whl (2.1 MB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.1/2.1 MB 24.4 MB/s eta 0:00:00
  Collecting awsebcli
    Downloading awsebcli-3.20.7.tar.gz (267 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 267.7/267.7 kB 79.3 MB/s eta 0:00:00
    Preparing metadata (setup.py): started
    Preparing metadata (setup.py): finished with status 'done'
  Collecting botocore<1.29.159,>1.23.41 (from awsebcli)
    Downloading botocore-1.29.158-py3-none-any.whl (10.9 MB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 10.9/10.9 MB 110.2 MB/s eta 0:00:00
  Collecting cement==2.8.2 (from awsebcli)
    Downloading cement-2.8.2.tar.gz (165 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 165.8/165.8 kB 52.9 MB/s eta 0:00:00
    Preparing metadata (setup.py): started
    Preparing metadata (setup.py): finished with status 'done'
  Collecting colorama<0.4.4,>=0.2.5 (from awsebcli)
    Downloading colorama-0.4.3-py2.py3-none-any.whl (15 kB)
  Collecting pathspec==0.10.1 (from awsebcli)
    Downloading pathspec-0.10.1-py3-none-any.whl (27 kB)
  Collecting python-dateutil<3.0.0,>=2.1 (from awsebcli)
    Downloading python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 247.7/247.7 kB 70.6 MB/s eta 0:00:00
  Collecting requests>=2.31 (from awsebcli)
    Downloading requests-2.31.0-py3-none-any.whl (62 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 62.6/62.6 kB 23.4 MB/s eta 0:00:00
  Requirement already satisfied: setuptools>=20.0 in /usr/local/lib/python3.11/site-packages (from awsebcli) (65.5.1)
  Collecting semantic_version==2.8.5 (from awsebcli)
    Downloading semantic_version-2.8.5-py2.py3-none-any.whl (15 kB)
  Collecting six<1.15.0,>=1.11.0 (from awsebcli)
    Downloading six-1.14.0-py2.py3-none-any.whl (10 kB)
  Collecting termcolor==1.1.0 (from awsebcli)
    Downloading termcolor-1.1.0.tar.gz (3.9 kB)
    Preparing metadata (setup.py): started
    Preparing metadata (setup.py): finished with status 'done'
  Collecting wcwidth<0.2.0,>=0.1.7 (from awsebcli)
    Downloading wcwidth-0.1.9-py2.py3-none-any.whl (19 kB)
  Collecting PyYAML<5.5,>=5.3.1 (from awsebcli)
    Downloading PyYAML-5.4.1.tar.gz (175 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 175.1/175.1 kB 53.1 MB/s eta 0:00:00
    Installing build dependencies: started
    Installing build dependencies: finished with status 'done'
    Getting requirements to build wheel: started
    Getting requirements to build wheel: finished with status 'error'
    error: subprocess-exited-with-error
    
    × Getting requirements to build wheel did not run successfully.
    │ exit code: 1
    ╰─> [68 lines of output]
        /tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
        !!
        
                ********************************************************************************
                The license_file parameter is deprecated, use license_files instead.
        
                By 2023-Oct-30, you need to update your project and remove deprecated calls
                or your builds will no longer be supported.
        
                See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
                ********************************************************************************
        
        !!
          parsed = self.parsers.get(option_name, lambda x: x)(value)
        running egg_info
        writing lib3/PyYAML.egg-info/PKG-INFO
        writing dependency_links to lib3/PyYAML.egg-info/dependency_links.txt
        writing top-level names to lib3/PyYAML.egg-info/top_level.txt
        Traceback (most recent call last):
          File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
            main()
          File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
            json_out['return_val'] = hook(**hook_input['kwargs'])
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
            return hook(config_settings)
                   ^^^^^^^^^^^^^^^^^^^^^
          File "/tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 341, in get_requires_for_build_wheel
            return self._get_build_requires(config_settings, requirements=['wheel'])
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 323, in _get_build_requires
            self.run_setup()
          File "/tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 338, in run_setup
            exec(code, locals())
          File "<string>", line 271, in <module>
          File "/tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/__init__.py", line 107, in setup
            return distutils.core.setup(**attrs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 185, in setup
            return run_commands(dist)
                   ^^^^^^^^^^^^^^^^^^
          File "/tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
            dist.run_commands()
          File "/tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
            self.run_command(cmd)
          File "/tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/dist.py", line 1234, in run_command
            super().run_command(command)
          File "/tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
            cmd_obj.run()
          File "/tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 314, in run
            self.find_sources()
          File "/tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 322, in find_sources
            mm.run()
          File "/tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 551, in run
            self.add_defaults()
          File "/tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 589, in add_defaults
            sdist.add_defaults(self)
          File "/tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/command/sdist.py", line 104, in add_defaults
            super().add_defaults()
          File "/tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 251, in add_defaults
            self._add_defaults_ext()
          File "/tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 336, in _add_defaults_ext
            self.filelist.extend(build_ext.get_source_files())
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "<string>", line 201, in get_source_files
          File "/tmp/pip-build-env-cmyxinnu/overlay/lib/python3.11/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
            raise AttributeError(attr)
        AttributeError: cython_sources
        [end of output]
    
    note: This error originates from a subprocess, and is likely not a problem with pip.
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  
  Notice:  A new release of pip is available: 23.1.2 -> 23.2.1
  Notice:  To update, run: pip install --upgrade pip
  The command '/bin/sh -c pip install --upgrade pip awsebcli' returned a non-zero code: 1
  
  Warning: Docker build failed with exit code 1, back off 3.461 seconds before retry.
  /usr/bin/docker build -t 5bedb4:043235e6b24b4a21b314a2ddeb1c2916 -f "/home/runner/work/_actions/hmanzur/actions-aws-eb/v1.0.0/Dockerfile" "/home/runner/work/_actions/hmanzur/actions-aws-eb/v1.0.0"
  Sending build context to Docker daemon   12.8kB
  
  Step 1/7 : FROM python:[3](https://github.com/Rubrick-AI/websocket/actions/runs/5730946873/job/15530786415#step:2:3)
   ---> 608c79ebc6d5
  Step 2/7 : ARG command="--version"
   ---> Using cache
   ---> 64649b4d89e9
  Step 3/7 : COPY entrypoint.sh /entrypoint.sh
   ---> Using cache
   ---> dd2589c73ba6
  Step 4/7 : RUN apt-get update -y
   ---> Using cache
   ---> 6e021d2baf45
  Step 5/7 : RUN pip install --upgrade pip awsebcli
   ---> Running in bb71da8865dd
  Requirement already satisfied: pip in /usr/local/lib/python3.11/site-packages (23.1.2)
  Collecting pip
    Downloading pip-23.2.1-py3-none-any.whl (2.1 MB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.1/2.1 MB 23.1 MB/s eta 0:00:00
  Collecting awsebcli
    Downloading awsebcli-3.20.7.tar.gz (267 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 267.7/267.7 kB 78.7 MB/s eta 0:00:00
    Preparing metadata (setup.py): started
    Preparing metadata (setup.py): finished with status 'done'
  Collecting botocore<1.29.159,>1.23.41 (from awsebcli)
    Downloading botocore-1.29.158-py3-none-any.whl (10.9 MB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 10.9/10.9 MB 122.4 MB/s eta 0:00:00
  Collecting cement==2.8.2 (from awsebcli)
    Downloading cement-2.8.2.tar.gz (165 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 165.8/165.8 kB 51.2 MB/s eta 0:00:00
    Preparing metadata (setup.py): started
    Preparing metadata (setup.py): finished with status 'done'
  Collecting colorama<0.4.4,>=0.2.5 (from awsebcli)
    Downloading colorama-0.4.3-py2.py3-none-any.whl (15 kB)
  Collecting pathspec==0.10.1 (from awsebcli)
    Downloading pathspec-0.10.1-py3-none-any.whl (27 kB)
  Collecting python-dateutil<3.0.0,>=2.1 (from awsebcli)
    Downloading python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 247.7/247.7 kB 63.0 MB/s eta 0:00:00
  Collecting requests>=2.31 (from awsebcli)
    Downloading requests-2.31.0-py3-none-any.whl (62 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 62.6/62.6 kB 23.2 MB/s eta 0:00:00
  Requirement already satisfied: setuptools>=20.0 in /usr/local/lib/python3.11/site-packages (from awsebcli) (65.5.1)
  Collecting semantic_version==2.8.5 (from awsebcli)
    Downloading semantic_version-2.8.5-py2.py3-none-any.whl (15 kB)
  Collecting six<1.15.0,>=1.11.0 (from awsebcli)
    Downloading six-1.14.0-py2.py3-none-any.whl (10 kB)
  Collecting termcolor==1.1.0 (from awsebcli)
    Downloading termcolor-1.1.0.tar.gz (3.9 kB)
    Preparing metadata (setup.py): started
    Preparing metadata (setup.py): finished with status 'done'
  Collecting wcwidth<0.2.0,>=0.1.7 (from awsebcli)
    Downloading wcwidth-0.1.9-py2.py3-none-any.whl (19 kB)
  Collecting PyYAML<5.5,>=5.3.1 (from awsebcli)
    Downloading PyYAML-5.4.1.tar.gz (175 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 175.1/175.1 kB 56.6 MB/s eta 0:00:00
    Installing build dependencies: started
    Installing build dependencies: finished with status 'done'
    Getting requirements to build wheel: started
    Getting requirements to build wheel: finished with status 'error'
    error: subprocess-exited-with-error
    
    × Getting requirements to build wheel did not run successfully.
    │ exit code: 1
    ╰─> [68 lines of output]
        /tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
        !!
        
                ********************************************************************************
                The license_file parameter is deprecated, use license_files instead.
        
                By 2023-Oct-30, you need to update your project and remove deprecated calls
                or your builds will no longer be supported.
        
                See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
                ********************************************************************************
        
        !!
          parsed = self.parsers.get(option_name, lambda x: x)(value)
        running egg_info
        writing lib3/PyYAML.egg-info/PKG-INFO
        writing dependency_links to lib3/PyYAML.egg-info/dependency_links.txt
        writing top-level names to lib3/PyYAML.egg-info/top_level.txt
        Traceback (most recent call last):
          File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
            main()
          File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
            json_out['return_val'] = hook(**hook_input['kwargs'])
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
            return hook(config_settings)
                   ^^^^^^^^^^^^^^^^^^^^^
          File "/tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 341, in get_requires_for_build_wheel
            return self._get_build_requires(config_settings, requirements=['wheel'])
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 323, in _get_build_requires
            self.run_setup()
          File "/tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 338, in run_setup
            exec(code, locals())
          File "<string>", line 271, in <module>
          File "/tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/__init__.py", line 107, in setup
            return distutils.core.setup(**attrs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 185, in setup
            return run_commands(dist)
                   ^^^^^^^^^^^^^^^^^^
          File "/tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
            dist.run_commands()
          File "/tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
            self.run_command(cmd)
          File "/tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/dist.py", line 1234, in run_command
            super().run_command(command)
          File "/tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
            cmd_obj.run()
          File "/tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 314, in run
            self.find_sources()
          File "/tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 322, in find_sources
            mm.run()
          File "/tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 551, in run
            self.add_defaults()
          File "/tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 589, in add_defaults
            sdist.add_defaults(self)
          File "/tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/command/sdist.py", line 104, in add_defaults
            super().add_defaults()
          File "/tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 251, in add_defaults
            self._add_defaults_ext()
          File "/tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 336, in _add_defaults_ext
            self.filelist.extend(build_ext.get_source_files())
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "<string>", line 201, in get_source_files
          File "/tmp/pip-build-env-wy1j5m2j/overlay/lib/python3.11/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
            raise AttributeError(attr)
        AttributeError: cython_sources
        [end of output]
    
    note: This error originates from a subprocess, and is likely not a problem with pip.
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  
  Notice:  A new release of pip is available: 23.1.2 -> 23.2.1
  Notice:  To update, run: pip install --upgrade pip
  The command '/bin/sh -c pip install --upgrade pip awsebcli' returned a non-zero code: 1
  
  Warning: Docker build failed with exit code 1, back off 8.894 seconds before retry.
  /usr/bin/docker build -t 5bedb4:043235e6b24b4a21b314a2ddeb1c2916 -f "/home/runner/work/_actions/hmanzur/actions-aws-eb/v1.0.0/Dockerfile" "/home/runner/work/_actions/hmanzur/actions-aws-eb/v1.0.0"
  Sending build context to Docker daemon   12.8kB
  
  Step 1/7 : FROM python:3
   ---> 608c79ebc6d5
  Step 2/7 : ARG command="--version"
   ---> Using cache
   ---> 6[4](https://github.com/Rubrick-AI/websocket/actions/runs/5730946873/job/15530786415#step:2:4)649b4d89e9
  Step 3/7 : COPY entrypoint.sh /entrypoint.sh
   ---> Using cache
   ---> dd2[5](https://github.com/Rubrick-AI/websocket/actions/runs/5730946873/job/15530786415#step:2:5)89c73ba[6](https://github.com/Rubrick-AI/websocket/actions/runs/5730946873/job/15530786415#step:2:6)
  Step 4/[7](https://github.com/Rubrick-AI/websocket/actions/runs/5730946873/job/15530786415#step:2:7) : RUN apt-get update -y
   ---> Using cache
   ---> 6e021d2baf45
  Step 5/7 : RUN pip install --upgrade pip awsebcli
   ---> Running in 6f3419f39eff
  Requirement already satisfied: pip in /usr/local/lib/python3.11/site-packages (23.1.2)
  Collecting pip
    Downloading pip-23.2.1-py3-none-any.whl (2.1 MB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.1/2.1 MB 24.0 MB/s eta 0:00:00
  Collecting awsebcli
    Downloading awsebcli-3.20.7.tar.gz (267 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 267.7/267.7 kB 72.0 MB/s eta 0:00:00
    Preparing metadata (setup.py): started
    Preparing metadata (setup.py): finished with status 'done'
  Collecting botocore<1.29.159,>1.23.41 (from awsebcli)
    Downloading botocore-1.29.15[8](https://github.com/Rubrick-AI/websocket/actions/runs/5730946873/job/15530786415#step:2:8)-py3-none-any.whl (10.[9](https://github.com/Rubrick-AI/websocket/actions/runs/5730946873/job/15530786415#step:2:9) MB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ [10](https://github.com/Rubrick-AI/websocket/actions/runs/5730946873/job/15530786415#step:2:10).9/10.9 MB 126.4 MB/s eta 0:00:00
  Collecting cement==2.8.2 (from awsebcli)
    Downloading cement-2.8.2.tar.gz (165 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 165.8/165.8 kB 54.8 MB/s eta 0:00:00
    Preparing metadata (setup.py): started
    Preparing metadata (setup.py): finished with status 'done'
  Collecting colorama<0.4.4,>=0.2.5 (from awsebcli)
    Downloading colorama-0.4.3-py2.py3-none-any.whl (15 kB)
  Collecting pathspec==0.10.1 (from awsebcli)
    Downloading pathspec-0.10.1-py3-none-any.whl (27 kB)
  Collecting python-dateutil<3.0.0,>=2.1 (from awsebcli)
    Downloading python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 247.7/247.7 kB 77.1 MB/s eta 0:00:00
  Collecting requests>=2.31 (from awsebcli)
    Downloading requests-2.31.0-py3-none-any.whl (62 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 62.6/62.6 kB 24.4 MB/s eta 0:00:00
  Requirement already satisfied: setuptools>=20.0 in /usr/local/lib/python3.[11](https://github.com/Rubrick-AI/websocket/actions/runs/5730946873/job/15530786415#step:2:11)/site-packages (from awsebcli) (65.5.1)
  Collecting semantic_version==2.8.5 (from awsebcli)
    Downloading semantic_version-2.8.5-py2.py3-none-any.whl (15 kB)
  Collecting six<1.15.0,>=1.11.0 (from awsebcli)
    Downloading six-1.14.0-py2.py3-none-any.whl (10 kB)
  Collecting termcolor==1.1.0 (from awsebcli)
    Downloading termcolor-1.1.0.tar.gz (3.9 kB)
    Preparing metadata (setup.py): started
    Preparing metadata (setup.py): finished with status 'done'
  Collecting wcwidth<0.2.0,>=0.1.7 (from awsebcli)
    Downloading wcwidth-0.1.9-py2.py3-none-any.whl (19 kB)
  Collecting PyYAML<5.5,>=5.3.1 (from awsebcli)
    Downloading PyYAML-5.4.1.tar.gz (175 kB)
       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 175.1/175.1 kB 56.5 MB/s eta 0:00:00
    Installing build dependencies: started
    Installing build dependencies: finished with status 'done'
    Getting requirements to build wheel: started
    Getting requirements to build wheel: finished with status 'error'
    error: subprocess-exited-with-error
    
    × Getting requirements to build wheel did not run successfully.
    │ exit code: 1
    ╰─> [68 lines of output]
        /tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
        !!
        
                ********************************************************************************
                The license_file parameter is deprecated, use license_files instead.
        
                By 2023-Oct-30, you need to update your project and remove deprecated calls
                or your builds will no longer be supported.
        
                See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
                ********************************************************************************
        
        !!
          parsed = self.parsers.get(option_name, lambda x: x)(value)
        running egg_info
        writing lib3/PyYAML.egg-info/PKG-INFO
        writing dependency_links to lib3/PyYAML.egg-info/dependency_links.txt
        writing top-level names to lib3/PyYAML.egg-info/top_level.txt
        Traceback (most recent call last):
          File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
            main()
          File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
            json_out['return_val'] = hook(**hook_input['kwargs'])
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/usr/local/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
            return hook(config_settings)
                   ^^^^^^^^^^^^^^^^^^^^^
          File "/tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 341, in get_requires_for_build_wheel
            return self._get_build_requires(config_settings, requirements=['wheel'])
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 323, in _get_build_requires
            self.run_setup()
          File "/tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/build_meta.py", line 338, in run_setup
            exec(code, locals())
          File "<string>", line 271, in <module>
          File "/tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/__init__.py", line 107, in setup
            return distutils.core.setup(**attrs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "/tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 185, in setup
            return run_commands(dist)
                   ^^^^^^^^^^^^^^^^^^
          File "/tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
            dist.run_commands()
          File "/tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
            self.run_command(cmd)
          File "/tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/dist.py", line [12](https://github.com/Rubrick-AI/websocket/actions/runs/5730946873/job/15530786415#step:2:12)34, in run_command
            super().run_command(command)
          File "/tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
            cmd_obj.run()
          File "/tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 3[14](https://github.com/Rubrick-AI/websocket/actions/runs/5730946873/job/15530786415#step:2:14), in run
            self.find_sources()
          File "/tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 322, in find_sources
            mm.run()
          File "/tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 551, in run
            self.add_defaults()
          File "/tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/command/egg_info.py", line 589, in add_defaults
            sdist.add_defaults(self)
          File "/tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/command/sdist.py", line 104, in add_defaults
            super().add_defaults()
          File "/tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 251, in add_defaults
            self._add_defaults_ext()
          File "/tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/_distutils/command/sdist.py", line 336, in _add_defaults_ext
            self.filelist.extend(build_ext.get_source_files())
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          File "<string>", line [20](https://github.com/Rubrick-AI/websocket/actions/runs/5730946873/job/15530786415#step:2:20)1, in get_source_files
          File "/tmp/pip-build-env-0cgan2zn/overlay/lib/python3.11/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
            raise AttributeError(attr)
        AttributeError: cython_sources
        [end of output]
    
    note: This error originates from a subprocess, and is likely not a problem with pip.
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  
  Notice:  A new release of pip is available: [23](https://github.com/Rubrick-AI/websocket/actions/runs/5730946873/job/15530786415#step:2:23).1.2 -> 23.2.1
  Notice:  To update, run: pip install --upgrade pip
  The command '/bin/sh -c pip install --upgrade pip awsebcli' returned a non-zero code: 1
  
Error: Docker build failed with exit code 1
```